### PR TITLE
Implements the new response format as described in #9.

### DIFF
--- a/PinRIsm-lib/Models/DTOs/OcrResultDto.cs
+++ b/PinRIsm-lib/Models/DTOs/OcrResultDto.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Enumeration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PinRism.Lib.Models.DTOs
+{
+    public class OcrResultDto
+    {
+        public bool Success { get; set; }
+        public Data Data { get; set; } = new();
+        public Meta Meta { get; set; } = new();
+        public string? Error { get; set; }
+    }
+
+    public class Data
+    {
+        public string? Name { get; set; }
+        public DateTime? BirthDate { get; set; }
+        public string? Address { get; set; }
+        public string? RawText {  get; set; }
+
+    }
+
+    public class Meta
+    {
+        public string? FileName {  get; set; }
+        public string ? MimeType { get; set; }
+        public long Length { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request updates the OCR API (POST /api/ocr/extract-text) to return a structured JSON response instead of plain text, as requested in [Issue #9](https://github.com/INPRISM-Labs/PinRism.Lib/issues/9). The new response format provides more useful information for clients and is more extensible for future needs.

Currently, only rawText is populated in the data object, as the OCR service provides only  unstructured text.

Additional fields like name, birthDate, and address are ready for future extraction improvements.